### PR TITLE
Fix parsing for updated gettex website

### DIFF
--- a/src/gettex_exchange/api.py
+++ b/src/gettex_exchange/api.py
@@ -61,6 +61,26 @@ class Api:
         """
         self._cache_timeout = cache_timeout
 
+    def _extract_saml_request_from_text(self, text: str) -> Optional[bytes]:
+        """
+        Extracts the SAML Request from text.
+
+        Returns:
+            Optional[bytes]: The SAML Request if found, else None.
+        """
+        patterns = [
+            r"(?:const|let|var)\s+samlRequest\s*=\s*`([\s\S]*?)`;",
+            r'(?:const|let|var)\s+samlRequest\s*=\s*"([\s\S]*?)";',
+            r"(?:const|let|var)\s+samlRequest\s*=\s*'([\s\S]*?)';",
+        ]
+
+        for pattern in patterns:
+            saml_request_search = re.search(pattern, text, re.MULTILINE)
+            if saml_request_search:
+                return saml_request_search.group(1).strip().encode("utf-8")
+
+        return None
+
     def _get_saml_request(self) -> bytes:
         """
         Fetches the SAML Request from the Gettex website.
@@ -81,19 +101,22 @@ class Api:
         if r.status_code != requests.codes.ok:
             raise requests.exceptions.HTTPError(r.status_code)
 
+        saml_request = self._extract_saml_request_from_text(r.text)
+
+        if saml_request:
+            logger.debug(f"SAML Request: {saml_request}")
+            return saml_request
+
         soup = BeautifulSoup(r.text, "html.parser")
-        widget_script = soup.find_all("script")[3]
-        saml_request_search = re.search(
-            r"const samlRequest=`([\S\s.]+)`;", widget_script.text
-        )
 
-        if not saml_request_search:
-            raise ValueError("No SAML Request found.")
+        for script in soup.find_all("script"):
+            saml_request = self._extract_saml_request_from_text(script.text)
 
-        saml_request = saml_request_search.group(1).encode("utf-8")
-        logger.debug(f"SAML Request: {saml_request}")
+            if saml_request:
+                logger.debug(f"SAML Request: {saml_request}")
+                return saml_request
 
-        return saml_request
+        raise ValueError("No SAML Request found.")
 
     def _create_session_and_token(self) -> None:
         """

--- a/src/gettex_exchange/stock.py
+++ b/src/gettex_exchange/stock.py
@@ -280,9 +280,15 @@ class Stock(Api):
         trade_date = data.get("q._TRADE_DATE")
         # 08:12
         trade_time = data.get("q._TRDTIM_1")
-        self._trade_date_time = datetime.strptime(
-            f"{trade_date} {trade_time}+0000", "%d %b %Y  %H:%M%z"
-        )
+
+        try:
+            self._trade_date_time = datetime.strptime(
+                f"{trade_date} {trade_time}+0000", "%d %b %Y %H:%M:%S%z"
+            )
+        except ValueError:
+            self._trade_date_time = datetime.strptime(
+                f"{trade_date} {trade_time}+0000", "%d %b %Y %H:%M%z"
+            )
         return self._trade_date_time
 
     @property

--- a/tests/fixtures/stock/stock_instrument_info.json
+++ b/tests/fixtures/stock/stock_instrument_info.json
@@ -35,7 +35,7 @@
       "q._TURNOVER": "+9747130.85",
       "q._PCTCHNG": "+5.283",
       "q._LOW_1": "+274.4",
-      "q._TRDTIM_1": "20:57",
+      "q._TRDTIM_1": "20:57:00",
       "x._DSPLY_NAME": "TESLA MOTORS",
       "q._TRADE_DATE": "22 AUG 2025",
       "q._COUNTRY": "DE"

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -208,6 +208,7 @@ def test_stock(mocked_responses):
         day=22,
         hour=20,
         minute=57,
+        second=0,
         tzinfo=timezone.utc,
     )
     assert s.wkn == "A1CX3T"


### PR DESCRIPTION
## Summary

Fixes parsing issues caused by changes on gettex.de.

## Changes

- Makes SAML request extraction independent of a fixed script tag index
- Searches the full HTML / script tags for the SAML request
- Supports multiple JavaScript declaration styles for `samlRequest`
- Updates trade date/time parsing to support seconds in `q._TRDTIM_1`

## Fixed errors

This fixes errors such as:

```
ValueError: No SAML Request found.
ValueError: time data '07 MAY 2026 09:00:28+0000' does not match format '%d %b %Y  %H:%M%z'
```

## Testing

Ran the existing test suite via Docker/Poetry:
```
docker compose -f docker-compose.test.yml run --rm gettex-exchange-test poetry run pytest -v
```

Result:
```
4 passed, 1 warning in 4.80s
```