### PR TITLE
feature: add additional quote fields and update fixtures

### DIFF
--- a/src/gettex_exchange/stock.py
+++ b/src/gettex_exchange/stock.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 
 import requests
 from loguru import logger
@@ -33,6 +33,15 @@ class Stock(Api):
         self._last_price: float = 0.0
         self._turnover: float = 0.0
         self._taxonomy: str = ""
+        self._taxonomy_level_2: str = ""
+        self._taxonomy_level_3: str = ""
+
+        self._currency: str = ""
+        self._accumulated_intraday_volume: int = 0
+        self._vwap: float = 0.0
+        self._last_trade_volume: int = 0
+        self._previous_close_price: float = 0.0
+        self._previous_close_date: date = date.today()
 
     def _get_quote_info(self, fields: list, component_id: str) -> dict:
         """
@@ -179,18 +188,31 @@ class Stock(Api):
         fields = [
             "x._TICKER",
             "x._DSPLY_NAME",
+            "x._LOCAL_ID",
+            "x._ISIN",
+            "x._CURRENCY",
             "q._TRDPRC_1",
             "q._NETCHNG_1",
             "q._PCTCHNG",
-            "q._COUNTRY",
-            "q._TRADE_DATE",
-            "q._TRDTIM_1",
-            "x._LOCAL_ID",
+            "q._BID",
+            "q._ASK",
+            "q._BIDSIZE",
+            "q._ASKSIZE",
+            "q._ACVOL_1",
+            "q._TURNOVER",
+            "q._VWAP",
+            "q._TRDVOL_1",
             "q._OPEN_PRC",
             "q._HIGH_1",
             "q._LOW_1",
-            "q._TURNOVER",
+            "q._HST_CLOSE",
+            "q._COUNTRY",
+            "q._TRADE_DATE",
+            "q._TRDTIM_1",
+            "q._HSTCLSDATE",
             "rkd.COMP_TAXONOMY_TRBC_CD_L1",
+            "rkd.COMP_TAXONOMY_TRBC_CD_L2",
+            "rkd.COMP_TAXONOMY_TRBC_CD_L3"
         ]
 
         return self._get_quote_info(fields, component_id)
@@ -358,3 +380,103 @@ class Stock(Api):
             data.get("rkd.COMP_TAXONOMY_TRBC_CD_L1")
         )
         return self._taxonomy
+
+    @property
+    def currency(self) -> str:
+        """
+        Fetches the currency for a stock.
+
+        Returns:
+            str: The currency.
+        """
+        data = self._get_quote_info_instrument_info()
+        self._currency = data.get("x._CURRENCY")
+        return self._currency
+
+    @property
+    def accumulated_intraday_volume(self) -> int:
+        """
+        Fetches the accumulated intraday volume for a stock.
+
+        Returns:
+            str: The accumulated intraday volume.
+        """
+        data = self._get_quote_info_instrument_info()
+        self._accumulated_intraday_volume = data.get("q._ACVOL_1")
+        return self._accumulated_intraday_volume
+
+    @property
+    def vwap(self) -> float:
+        """
+        Fetches the VWAP (Volume Weighted Average Price) for a stock.
+
+        Returns:
+            str: The VWAP (Volume Weighted Average Price).
+        """
+        data = self._get_quote_info_instrument_info()
+        self._vwap = data.get("q._VWAP")
+        return self._vwap
+
+    @property
+    def last_trade_volume(self) -> int:
+        """
+        Fetches the trade volume from the last trade for a stock.
+
+        Returns:
+            str: The trade volume from the last trade.
+        """
+        data = self._get_quote_info_instrument_info()
+        self._last_trade_volume = data.get("q._TRDVOL_1")
+        return self._last_trade_volume
+
+    @property
+    def previous_close_price(self) -> float:
+        """
+        Fetches the historical close price for a stock.
+
+        Returns:
+            str: The historical close price.
+        """
+        data = self._get_quote_info_instrument_info()
+        self._previous_close_price = data.get("q._HST_CLOSE")
+        return self._previous_close_price
+
+    @property
+    def previous_close_date(self) -> date:
+        """
+        Fetches the historical close price for a stock.
+
+        Returns:
+            str: The historical close price.
+        """
+        data = self._get_quote_info_instrument_info()
+        previous_close_date = data.get("q._HSTCLSDATE")
+        self._previous_close_date = datetime.strptime(
+            previous_close_date, "%d %b %Y"
+        ).date()
+        return self._previous_close_date
+
+    @property
+    def taxonomy_level_2(self) -> str:
+        """
+        Fetches the TRBC business sector code for a stock.
+
+        Returns:
+            str: The TRBC business sector code.
+        """
+        data = self._get_quote_info_instrument_info()
+        self._taxonomy_level_2 = data.get("rkd.COMP_TAXONOMY_TRBC_CD_L2")
+        return self._taxonomy_level_2
+
+    @property
+    def taxonomy_level_3(self) -> str:
+        """
+        Fetches the TRBC industry group code for a stock.
+
+        Returns:
+            str: The TRBC industry group code.
+        """
+        data = self._get_quote_info_instrument_info()
+        self._taxonomy_level_3 = data.get("rkd.COMP_TAXONOMY_TRBC_CD_L3")
+        return self._taxonomy_level_3
+

--- a/tests/fixtures/stock/stock_info_matrix_price.json
+++ b/tests/fixtures/stock/stock_info_matrix_price.json
@@ -8,7 +8,7 @@
     "feeliable": true,
     "appcodes": ["TRS"]
   },
-  "data": [{ "q._BID": "+290.1", "x.RIC": "TSLA.GTX", "q._ASK": "+290.25" }],
+  "data": [{ "q._BID": "+363.05", "x.RIC": "TSLA.GTX", "q._ASK": "+363.45" }],
   "status": "OK",
   "metadata": {
     "q._BID": { "type": "float.price", "streaming": "_BID" },

--- a/tests/fixtures/stock/stock_info_matrix_size.json
+++ b/tests/fixtures/stock/stock_info_matrix_size.json
@@ -8,7 +8,7 @@
     "feeliable": true,
     "appcodes": ["TRS"]
   },
-  "data": [{ "x.RIC": "TSLA.GTX", "q.ASKSIZE": "+365", "q.BIDSIZE": "+375" }],
+  "data": [{ "x.RIC": "TSLA.GTX", "q.ASKSIZE": "+375", "q.BIDSIZE": "+375" }],
   "status": "OK",
   "metadata": {
     "q.BIDSIZE": { "type": "int", "streaming": "BIDSIZE" },

--- a/tests/fixtures/stock/stock_instrument_info.json
+++ b/tests/fixtures/stock/stock_instrument_info.json
@@ -1,68 +1,179 @@
 {
   "request": {
-    "rics": ["TSLA.GTX"],
+    "rics": [
+      "TSLA.GTX"
+    ],
     "fids": [
       "x._TICKER",
       "x._DSPLY_NAME",
+      "x._LOCAL_ID",
+      "x._ISIN",
+      "x._CURRENCY",
       "q._TRDPRC_1",
       "q._NETCHNG_1",
       "q._PCTCHNG",
-      "q._COUNTRY",
-      "q._TRADE_DATE",
-      "q._TRDTIM_1",
-      "x._LOCAL_ID",
+      "q._BID",
+      "q._ASK",
+      "q._BIDSIZE",
+      "q._ASKSIZE",
+      "q._ACVOL_1",
+      "q._TURNOVER",
+      "q._VWAP",
+      "q._TRDVOL_1",
       "q._OPEN_PRC",
       "q._HIGH_1",
       "q._LOW_1",
-      "q._TURNOVER",
-      "rkd.COMP_TAXONOMY_TRBC_CD_L1"
+      "q._HST_CLOSE",
+      "q._COUNTRY",
+      "q._TRADE_DATE",
+      "q._TRDTIM_1",
+      "q._HSTCLSDATE",
+      "rkd.COMP_TAXONOMY_TRBC_CD_L1",
+      "rkd.COMP_TAXONOMY_TRBC_CD_L2",
+      "rkd.COMP_TAXONOMY_TRBC_CD_L3"
     ],
     "currency": "USD",
     "country": "US",
     "classSchemeId": "1006052",
     "feeliable": true,
-    "appcodes": ["TRS"]
+    "appcodes": [
+      "TRS"
+    ]
   },
   "data": [
     {
       "rkd.COMP_TAXONOMY_TRBC_CD_L1": "53",
-      "q._OPEN_PRC": "+275.75",
-      "q._NETCHNG_1": "+14.55",
+      "rkd.COMP_TAXONOMY_TRBC_CD_L2": "5310",
+      "q._OPEN_PRC": "+351.05",
+      "rkd.COMP_TAXONOMY_TRBC_CD_L3": "531010",
       "x._LOCAL_ID": "A1CX3T",
       "x._TICKER": "TL0",
-      "q._HIGH_1": "+290.4",
-      "q._TRDPRC_1": "+289.95",
-      "q._TURNOVER": "+9747130.85",
-      "q._PCTCHNG": "+5.283",
-      "q._LOW_1": "+274.4",
-      "q._TRDTIM_1": "20:57",
+      "x._CURRENCY": "EUR",
+      "q._TRDPRC_1": "+363.3",
+      "q._TURNOVER": "+5112392.25",
+      "q._ACVOL_1": "14201",
+      "q._VWAP": "+360.00227",
+      "q._TRDVOL_1": "+1",
+      "q._ASKSIZE": "+375",
+      "q._HST_CLOSE": "+350.2",
+      "q._NETCHNG_1": "+13.1",
+      "q._BIDSIZE": "+375",
+      "q._HIGH_1": "+366",
+      "q._HSTCLSDATE": "07 MAY 2026",
+      "q._PCTCHNG": "+3.741",
+      "q._LOW_1": "+350.55",
+      "q._TRDTIM_1": "20:56:10",
+      "q._BID": "+363.05",
       "x._DSPLY_NAME": "TESLA MOTORS",
-      "q._TRADE_DATE": "22 AUG 2025",
-      "q._COUNTRY": "DE"
+      "q._TRADE_DATE": "08 MAY 2026",
+      "q._COUNTRY": "DE",
+      "x._ISIN": "US88160R1014",
+      "q._ASK": "+363.45"
     }
   ],
   "status": "OK",
   "metadata": {
-    "x._TICKER": { "type": "string" },
-    "x._DSPLY_NAME": { "type": "string" },
-    "q._TRDPRC_1": { "type": "float.price", "streaming": "_TRDPRC_1" },
-    "q._NETCHNG_1": { "type": "float.price.change", "streaming": "_NETCHNG_1" },
+    "x._TICKER": {
+      "type": "string"
+    },
+    "x._DSPLY_NAME": {
+      "type": "string"
+    },
+    "x._LOCAL_ID": {
+      "type": "string"
+    },
+    "x._ISIN": {
+      "type": "string"
+    },
+    "x._CURRENCY": {
+      "type": "string.currency"
+    },
+    "q._TRDPRC_1": {
+      "type": "float.price",
+      "streaming": "_TRDPRC_1"
+    },
+    "q._NETCHNG_1": {
+      "type": "float.price.change",
+      "streaming": "_NETCHNG_1"
+    },
     "q._PCTCHNG": {
       "type": "float.percentage.change",
       "streaming": "_PCTCHNG"
     },
-    "q._COUNTRY": { "type": "string.country", "streaming": "_COUNTRY" },
+    "q._BID": {
+      "type": "float.price",
+      "streaming": "_BID"
+    },
+    "q._ASK": {
+      "type": "float.price",
+      "streaming": "_ASK"
+    },
+    "q._BIDSIZE": {
+      "type": "int",
+      "streaming": "_BIDSIZE"
+    },
+    "q._ASKSIZE": {
+      "type": "int",
+      "streaming": "_ASKSIZE"
+    },
+    "q._ACVOL_1": {
+      "type": "int",
+      "streaming": "_ACVOL_1"
+    },
+    "q._TURNOVER": {
+      "type": "float.price",
+      "streaming": "_TURNOVER"
+    },
+    "q._VWAP": {
+      "type": "float",
+      "streaming": "_VWAP"
+    },
+    "q._TRDVOL_1": {
+      "type": "int",
+      "streaming": "_TRDVOL_1"
+    },
+    "q._OPEN_PRC": {
+      "type": "float.price",
+      "streaming": "_OPEN_PRC"
+    },
+    "q._HIGH_1": {
+      "type": "float.price",
+      "streaming": "_HIGH_1"
+    },
+    "q._LOW_1": {
+      "type": "float.price",
+      "streaming": "_LOW_1"
+    },
+    "q._HST_CLOSE": {
+      "type": "float.price",
+      "streaming": "_HST_CLOSE"
+    },
+    "q._COUNTRY": {
+      "type": "string.country",
+      "streaming": "_COUNTRY"
+    },
     "q._TRADE_DATE": {
       "format": "date.tr",
       "type": "date",
       "streaming": "_TRADE_DATE"
     },
-    "q._TRDTIM_1": { "type": "time", "streaming": "_TRDTIM_1" },
-    "x._LOCAL_ID": { "type": "string" },
-    "q._OPEN_PRC": { "type": "float.price", "streaming": "_OPEN_PRC" },
-    "q._HIGH_1": { "type": "float.price", "streaming": "_HIGH_1" },
-    "q._LOW_1": { "type": "float.price", "streaming": "_LOW_1" },
-    "q._TURNOVER": { "type": "float.price", "streaming": "_TURNOVER" },
-    "rkd.COMP_TAXONOMY_TRBC_CD_L1": { "type": "string.sector" }
+    "q._TRDTIM_1": {
+      "type": "time",
+      "streaming": "_TRDTIM_1"
+    },
+    "q._HSTCLSDATE": {
+      "format": "date.tr",
+      "type": "date",
+      "streaming": "_HSTCLSDATE"
+    },
+    "rkd.COMP_TAXONOMY_TRBC_CD_L1": {
+      "type": "string"
+    },
+    "rkd.COMP_TAXONOMY_TRBC_CD_L2": {
+      "type": "string"
+    },
+    "rkd.COMP_TAXONOMY_TRBC_CD_L3": {
+      "type": "string"
+    }
   }
 }

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -168,10 +168,14 @@ def mocked_responses():
                     {
                         "rics": "TSLA.GTX",
                         "fids": (
-                            "x._TICKER,x._DSPLY_NAME,q._TRDPRC_1,q._NETCHNG_1,"
-                            "q._PCTCHNG,q._COUNTRY,q._TRADE_DATE,q._TRDTIM_1,"
-                            "x._LOCAL_ID,q._OPEN_PRC,q._HIGH_1,q._LOW_1,"
-                            "q._TURNOVER,rkd.COMP_TAXONOMY_TRBC_CD_L1"
+                            "x._TICKER,x._DSPLY_NAME,x._LOCAL_ID,x._ISIN,x._CURRENCY,"
+                            "q._TRDPRC_1,q._NETCHNG_1,q._PCTCHNG,q._BID,q._ASK,"
+                            "q._BIDSIZE,q._ASKSIZE,q._ACVOL_1,q._TURNOVER,q._VWAP,"
+                            "q._TRDVOL_1,q._OPEN_PRC,q._HIGH_1,q._LOW_1,q._HST_CLOSE,"
+                            "q._COUNTRY,q._TRADE_DATE,q._TRDTIM_1,q._HSTCLSDATE,"
+                            "rkd.COMP_TAXONOMY_TRBC_CD_L1,"
+                            "rkd.COMP_TAXONOMY_TRBC_CD_L2,"
+                            "rkd.COMP_TAXONOMY_TRBC_CD_L3"
                         ),
                     }
                 )
@@ -188,31 +192,47 @@ def test_stock(mocked_responses):
     s = Stock("US88160R1014")
     assert s.isin == "US88160R1014"
 
-    assert s.bid_price == 290.1
-    assert s.ask_price == 290.25
+    assert s.bid_price == 363.05
+    assert s.ask_price == 363.45
 
     assert s.bid_size == 375
-    assert s.ask_size == 365
+    assert s.ask_size == 375
 
     sleep(2.5)
 
     assert s.ticker == "TL0"
     assert s.display_name == "TESLA MOTORS"
-    assert s.low_price == 274.4
-    assert s.price_change == 14.55
-    assert s.percent_change == 5.283
+    assert s.low_price == 350.55
+    assert s.price_change == 13.1
+    assert s.percent_change == 3.741
     assert s.country == "DE"
     assert s.trade_date_time == datetime(
-        year=2025,
-        month=8,
-        day=22,
+        year=2026,
+        month=5,
+        day=8,
         hour=20,
-        minute=57,
+        minute=56,
+        second=10,
         tzinfo=timezone.utc,
     )
     assert s.wkn == "A1CX3T"
-    assert s.open_price == 275.75
-    assert s.high_price == 290.4
-    assert s.last_price == 289.95
-    assert s.turnover == 9747130.85
+    assert s.open_price == 351.05
+    assert s.high_price == 366
+    assert s.last_price == 363.3
+    assert s.turnover == 5112392.25
     assert s.taxonomy == "Consumer"
+    assert s.taxonomy_level_2 == 5310
+    assert s.taxonomy_level_3 == 531010
+    assert s.currency == "EUR"
+    assert s.accumulated_intraday_volume == 14201
+    assert s.vwap == 360.00227
+    assert s.last_trade_volume == 1
+    assert s.previous_close_price == 350.2
+    assert s.previous_close_date == datetime(
+        year=2026,
+        month=5,
+        day=7,
+        tzinfo=timezone.utc,
+    )
+
+    assert False, s._get_quote_info_instrument_info()


### PR DESCRIPTION
## Summary
Adds additional quote fields exposed by gettex.de.

## Changes
Adds currency information
Adds accumulated trading volume
Adds VWAP
Adds last trade volume
Adds previous historical close price
Adds previous historical close date
Adds additional TRBC taxonomy level codes

## Testing
Ran the existing test suite via Docker:
```
docker compose -f docker-compose.test.yml run --rm gettex-exchange-test poetry run pytest -v
```

## Result:
```
4 passed, 1 warning in 4.82s
```

## Notes
The newly added TRBC taxonomy level 2 and level 3 values are currently exposed as raw codes. They could be translated to human-readable names in a future PR, similar to the existing level 1 taxonomy translation.

A possible MIT-licensed reference for the TRBC code mapping is available here:
https://github.com/swanest/TRBC/blob/master/data/data.json